### PR TITLE
Adding a basic server using express and rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build/**
 !build/index.html
+server

--- a/app.js
+++ b/app.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import hbs from 'hbs';
+
+const app = express();
+
+app.set('view engine', 'html');
+app.set('views', './build');
+
+app.engine('html', hbs.__express);
+app.use(express.static('build'));
+
+app.get('*', function (req, res) {
+  res.render('index', {});
+});
+
+app.listen(3000, function () {
+  console.log('Learn-rollup app started on port 3000!'); // eslint-disable-line no-console
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "rollup -c --watch",
     "reload": "livereload 'build/'",
-    "watch": "npm-run-all --parallel reload dev",
+    "start": "rollup -c rollup.server.config.js && node server/app.js",
+    "watch": "npm-run-all --parallel reload dev start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -38,6 +39,8 @@
     "rollup-watch": "^2.5.0"
   },
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "express": "^4.14.0",
+    "hbs": "^4.0.1"
   }
 }

--- a/rollup.server.config.js
+++ b/rollup.server.config.js
@@ -1,0 +1,8 @@
+// Rollup plugins
+
+export default {
+  entry: 'app.js',
+  dest: 'server/app.js',
+  format: 'cjs',
+  external: [ 'express', 'hbs' ]
+};


### PR DESCRIPTION
The purpose of this PR:
- Explain the use of rollup on server side files.
- Use an specific config for the `app.js` file.
- Create a local server and expose the app in `http://localhost:3000`

Please, let me know your feedback @jlengstorf
This might look a bit more fancy than opening the index file directly on the browser.
