### PR TITLE
feat(babel): remove outdated Babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/jlengstorf/learn-rollup#readme",
   "devDependencies": {
-    "babel-preset-es2015-rollup": "^3.0.0",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
     "cssnano": "^3.9.1",
     "livereload": "^0.6.0",
     "npm-run-all": "^3.1.2",


### PR DESCRIPTION
- remove `babel-preset-es2015-rollup`
- add `babel-preset-es2015`
- add `babel-plugin-external-helpers`

fix jlengstorf/learn-rollup#34