### PR TITLE
fix: bug `Uint8Array without null bytes`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,12 +28,12 @@ export default {
       ],
       extensions: [ '.css' ],
     }),
+    commonjs(),
     resolve({
       jsnext: true,
       main: true,
       browser: true,
     }),
-    commonjs(),
     eslint({
       exclude: [
         'src/styles/**',


### PR DESCRIPTION
Hi, I had a problem when executing the build.

    The argument 'path' must be a string or Uint8Array without null bytes. Received '\ u0000commonjs-proxy

And I solve the problem by following this issue

https://github.com/rollup/rollup/issues/1782

Thanks for your post, it helped me a lot!